### PR TITLE
[25기 김용현] 검색 결과창 초기 레이아웃

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -3,13 +3,14 @@ import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 
 import Main from './pages/Main/Main';
 import Login from './pages/Login/Login';
+import SearchResult from './pages/SearchResult/SearchResult';
 
 class Routes extends React.Component {
   render() {
     return (
       <Router>
         <Switch>
-          <Route exact path="/" component={Main} />
+          <Route exact path="/" component={SearchResult} />
           <Route exact path="/login" component={Login} />
         </Switch>
       </Router>

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -3,14 +3,13 @@ import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 
 import Main from './pages/Main/Main';
 import Login from './pages/Login/Login';
-import SearchResult from './pages/SearchResult/SearchResult';
 
 class Routes extends React.Component {
   render() {
     return (
       <Router>
         <Switch>
-          <Route exact path="/" component={SearchResult} />
+          <Route exact path="/" component={Main} />
           <Route exact path="/login" component={Login} />
         </Switch>
       </Router>

--- a/src/pages/SearchResult/SearchResult.js
+++ b/src/pages/SearchResult/SearchResult.js
@@ -1,0 +1,80 @@
+import React, { Component } from 'react';
+import './SearchResult.scss';
+
+class SearchResult extends Component {
+  constructor() {
+    super();
+    this.state = {
+      productList: [],
+    };
+  }
+
+  // API 주소 임의로 넣어놓음
+
+  // componentDidMount() {
+  //   fetch(
+  //     'https://f960-211-106-114-186.ngrok.io/product/menu/category/1/detail'
+  //   )
+  //     .then(res => res.json())
+  //     .then(data => {
+  //       this.setState({
+  //         productList: data.result,
+  //       });
+  //     });
+  // }
+
+  render() {
+    // const {
+    //   id,
+    //   mainImage,
+    //   category,
+    //   name,
+    //   cookingTime,
+    //   serving,
+    //   like,
+    //   this_user_like,
+    // } = this.state.productList;
+    return (
+      <div className="result">
+        <div className="resultHeader">
+          <div className="resultHeaderBox">
+            <div className="resultInput"></div>
+            <p>
+              <em className="resultContent">샐러드</em>에 대해{' '}
+              <em className="resultContent">총 22건</em>의 검색결과가 있습니다.
+            </p>
+          </div>
+        </div>
+        <div className="resultList">
+          {/* {this.state.productList &&
+            this.state.productList.map(p => {
+              return (
+                <ProductPreview
+                  key={p.id}
+                  productId={p.id}
+                  mainImage={p.mainImage}
+                  category={p.category}
+                  name={p.name}
+                  cookingTime={p.cookingTime}
+                  serving={p.serving}
+                  like={p.like}
+                  userLike={p.this_user_like}
+                />
+              );
+            })} */}
+          <div className="product">1</div>
+          <div className="product">2</div>
+          <div className="product">3</div>
+          <div className="product">4</div>
+          <div className="product">5</div>
+          <div className="product">6</div>
+          <div className="product">7</div>
+          <div className="product">8</div>
+          <div className="product">9</div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default SearchResult;

--- a/src/pages/SearchResult/SearchResult.scss
+++ b/src/pages/SearchResult/SearchResult.scss
@@ -1,0 +1,47 @@
+.result {
+  display: block;
+  max-width: 960px;
+  margin: 0 auto;
+
+  .resultHeader {
+    margin-top: 187px;
+    display: flex;
+    justify-content: center;
+
+    .resultHeaderBox {
+      margin: 0 auto 80px auto;
+
+      .resultInput {
+        width: 675px;
+        height: 80px;
+        border: 3px solid black;
+        background-color: orange;
+      }
+      p {
+        width: 675px;
+        margin: 40px 0 15px;
+        text-align: center;
+        font-size: 25px;
+        font-weight: 300;
+        .resultContent {
+          color: #21685a;
+        }
+      }
+    }
+  }
+
+  .resultList {
+    display: flex;
+    justify-content: center;
+    max-width: 960px;
+    flex-wrap: wrap;
+    padding-bottom: 96px;
+
+    .product {
+      display: block;
+      width: 320px;
+      height: 423px;
+      border: 2px solid green;
+    }
+  }
+}


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 검색 결과 레이아웃 및 상품 미리보기 컴포넌트 연결

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 검색 결과창 초기 레이아웃 완성
2. 상품 컴포넌트와 검색창 컴포넌트 연결할  초기 레이아웃 구성
<img width="1792" alt="스크린샷 2021-10-13 오전 10 41 16" src="https://user-images.githubusercontent.com/81367886/137052483-95e341a8-42a6-4d74-8d21-004f41ffe54d.png">


<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 컴포넌트를 사용할 방법을 생각하며 레이아웃을 잡으면서 전체적인 틀을 생각할 수 있었다.

<br />

## :: 기타 질문 및 특이 사항
- 상품 리스트 출력 부분에서 grid를 사용해보려고 했는데 잘 되지 않아서 다른 방법을 사용했습니다.
- 지금과 같이 결과값을 리스트로 받아서 보여주려고 할때 그리드를 사용하면 어떨지 궁금합니다!
